### PR TITLE
Fixing broken links back to the gh repo

### DIFF
--- a/META.json
+++ b/META.json
@@ -60,15 +60,15 @@
    "release_status" : "stable",
    "resources" : {
       "bugtracker" : {
-         "web" : "https://github.com/Corion/AI-Ollama-Client/issues"
+         "web" : "https://github.com/Corion/AI-Ollama/issues"
       },
       "license" : [
          "https://dev.perl.org/licenses/"
       ],
       "repository" : {
          "type" : "git",
-         "url" : "git://github.com/Corion/AI-Ollama-Client.git",
-         "web" : "https://github.com/Corion/AI-Ollama-Client"
+         "url" : "git://github.com/Corion/AI-Ollama.git",
+         "web" : "https://github.com/Corion/AI-Ollama"
       }
    },
    "version" : "0.03",

--- a/META.yml
+++ b/META.yml
@@ -37,9 +37,9 @@ requires:
   perl: '5.020'
   stable: '0.031'
 resources:
-  bugtracker: https://github.com/Corion/AI-Ollama-Client/issues
+  bugtracker: https://github.com/Corion/AI-Ollama/issues
   license: https://dev.perl.org/licenses/
-  repository: git://github.com/Corion/AI-Ollama-Client.git
+  repository: git://github.com/Corion/AI-Ollama.git
 version: '0.03'
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'
 x_static_install: 1

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,7 @@ my $module = 'AI::Ollama::Client';
 (my $main_file = "lib/$module.pm" ) =~ s!::!/!g;
 (my $distbase = $module) =~ s!::!-!g;
 my $distlink = $distbase;
+(my $distrepo = $distbase) =~ s!-Client$!!g;
 
 my @tests = map { glob $_ } 't/*.t', 't/*/*.t';
 
@@ -26,12 +27,12 @@ my %module = (
         "meta-spec" => { version => 2 },
         resources => {
             repository => {
-                web => "https://github.com/Corion/$distlink",
-                url => "git://github.com/Corion/$distlink.git",
+                web => "https://github.com/Corion/$distrepo",
+                url => "git://github.com/Corion/$distrepo.git",
                 type => 'git',
             },
             bugtracker  => {
-              web    => "https://github.com/Corion/$distbase/issues",
+              web    => "https://github.com/Corion/$distrepo/issues",
               # mailto => 'meta-bugs@example.com',
             },
             license    => "https://dev.perl.org/licenses/",
@@ -177,9 +178,9 @@ INSTALL
         $parser->parse_from_file($_[0]);
         my $readme_mkdn = <<STATUS . $parser->as_markdown;
 
-[![Windows](https://github.com/Corion/$distbase/workflows/windows/badge.svg)](https://github.com/Corion/$distbase/actions?query=workflow%3Awindows)
-[![MacOS](https://github.com/Corion/$distbase/workflows/macos/badge.svg)](https://github.com/Corion/$distbase/actions?query=workflow%3Amacos)
-[![Linux](https://github.com/Corion/$distbase/workflows/linux/badge.svg)](https://github.com/Corion/$distbase/actions?query=workflow%3Alinux)
+[![Windows](https://github.com/Corion/$distrepo/workflows/windows/badge.svg)](https://github.com/Corion/$distrepo/actions?query=workflow%3Awindows)
+[![MacOS](https://github.com/Corion/$distrepo/workflows/macos/badge.svg)](https://github.com/Corion/$distrepo/actions?query=workflow%3Amacos)
+[![Linux](https://github.com/Corion/$distrepo/workflows/linux/badge.svg)](https://github.com/Corion/$distrepo/actions?query=workflow%3Alinux)
 
 STATUS
         update_file( 'README.mkdn', $readme_mkdn );


### PR DESCRIPTION
```my $module = 'AI::Ollama::Client';
(my $main_file = "lib/$module.pm" ) =~ s!::!/!g;
(my $distbase = $module) =~ s!::!-!g;
my $distlink = $distbase;
```

I noticed on metacpan that the links to the github repo were broken due to the module being `AI::Ollama::Client` and the repo `AI-Ollama`. I figured I could raise an issue, or just provide _a_ fix. As I'm not sure if you want to correct this by renaming the repo to include -Client or keep things how they are now - if you want to stick with as-is. This simple fix should work. I hope I caught all the references.

I just added this line and updated github references from distlink/distbase to distrepo

```
(my $distrepo = $distbase) =~ s!-Client$!!g;
```